### PR TITLE
Fix model out-of-step when UI resubmits same expression after an error.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,9 +9,9 @@
 	<link rel='icon' type='image/png' href='favicon.png'>
 	<link rel='stylesheet' href='Assets/global.css'>
 	<link rel='stylesheet' href='Assets/bundle.css'>
-	<script type="text/javascript" src="https://cdn.ctat.cs.cmu.edu/html-editor/js/jquery.js"></script>
-    <script type="text/javascript" src="Assets/ctat.min.js"></script>
-	<script type="text/javascript" src="Assets/ctatloader.js"></script>
+	<script type="text/javascript" src="Assets/jquery.min.js"></script>
+	<script type="text/javascript" src="Assets/ctat.min.js"></script>
+<!--	<script type="text/javascript" src="Assets/ctatloader.js"></script>  in bundle.js -->
 	<script type="text/javascript" src="Assets/nools.js"></script>
 	<script type="text/javascript" src="Assets/modelhelperfuns.js"></script>
 </head>

--- a/src/stores/equation.js
+++ b/src/stores/equation.js
@@ -30,8 +30,9 @@ function createDraftEquation() {
 	const { subscribe, set, update } = writable(initial);
     const apply = (student=true) => update(eqn => {
         if (student) {
+            console.log("eqn:", eqn, "history.current", get(history).current);
             var sai = new CTATSAI(dragOperation.side, dragOperation.from + "To" + dragOperation.to, parse.algStringify(eqn));
-            if (CTATCommShell.commShell)
+            if ((CTATCommShell.commShell) && (get(history).current !== eqn))
                 CTATCommShell.commShell.processComponentAction(sai);
         }
         


### PR DESCRIPTION
1. Use local jquery.min.js instead of CDN jquery.js.
2. In createDraftEquation(), do not submit a student SAI that matches the current one.